### PR TITLE
Add backlog-header color so it doesn't disappear

### DIFF
--- a/backlog.scss
+++ b/backlog.scss
@@ -1,5 +1,6 @@
 @import "colors";
 
+.ghx-backlog-header,
 .ghx-end {
     background: $brightSecondary !important;
     color: $primary !important;


### PR DESCRIPTION
Before:
Backlog sprint headings would be the same color as the background
![image](https://cloud.githubusercontent.com/assets/10931978/18885451/92f550f6-84a0-11e6-9cac-1527d5203f07.png)
![image](https://cloud.githubusercontent.com/assets/10931978/18885461/9cd56408-84a0-11e6-9451-436ef47707e0.png)

After:
Spring headings have the standard text color
![image](https://cloud.githubusercontent.com/assets/10931978/18885471/a3b94bf4-84a0-11e6-9f76-f36182b98d8f.png)
