### PR TITLE
Restore the red background color for busted columns

### DIFF
--- a/agile.scss
+++ b/agile.scss
@@ -37,4 +37,7 @@
     background: $brighterSecondary;
 }
 
-
+.ghx-columns .ghx-busted,
+.ghx-columns .ghx-busted-max {
+    background: $column_warning !important;
+}

--- a/colors.scss
+++ b/colors.scss
@@ -12,3 +12,4 @@ $brightHighlight: lighten($colour, 10%);
 $brighterHighlight: lighten($colour, 20%);
 $brightestHighlight: lighten($colour, 30%);
 
+$column_warning: #d04437;

--- a/jira.css
+++ b/jira.css
@@ -46,7 +46,6 @@ form.aui option,
 
 #syntaxplugin span[style*="black"] {
   color: #FFFFFF !important; }
-
 #syntaxplugin span[style*="blue"] {
   color: #42769a !important; }
 
@@ -84,6 +83,10 @@ code {
 .ghx-column-headers .ghx-column,
 .ghx-columns .ghx-column {
   background: #4d4d4d; }
+
+.ghx-columns .ghx-busted,
+.ghx-columns .ghx-busted-max {
+  background: #d04437 !important; }
 
 .ghx-backlog-header,
 .ghx-end {


### PR DESCRIPTION
"Busted columns" (according to the CSS class name) are columns displayed
in the sprint column view, which have more tickets than the set maximum.
The default JIRA theme highlights the column with red, which is what
this patch fixes.

![j](https://user-images.githubusercontent.com/9215359/28677683-2601d5a4-72a3-11e7-8c5c-694b05890d7f.png)