### PR TITLE
Display flagged tickets with red background

### DIFF
--- a/agile.scss
+++ b/agile.scss
@@ -37,4 +37,6 @@
     background: $brighterSecondary;
 }
 
-
+.ghx-flagged * {
+    background-color: $flagged_ticket;
+}

--- a/colors.scss
+++ b/colors.scss
@@ -12,3 +12,4 @@ $brightHighlight: lighten($colour, 10%);
 $brighterHighlight: lighten($colour, 20%);
 $brightestHighlight: lighten($colour, 30%);
 
+$flagged_ticket: darkred;

--- a/jira.css
+++ b/jira.css
@@ -46,7 +46,6 @@ form.aui option,
 
 #syntaxplugin span[style*="black"] {
   color: #FFFFFF !important; }
-
 #syntaxplugin span[style*="blue"] {
   color: #42769a !important; }
 
@@ -84,6 +83,9 @@ code {
 .ghx-column-headers .ghx-column,
 .ghx-columns .ghx-column {
   background: #4d4d4d; }
+
+.ghx-flagged * {
+  background-color: darkred; }
 
 .ghx-backlog-header,
 .ghx-end {


### PR DESCRIPTION
The default theme displays light orange background, but the white text
in this theme isn't very readable on that background, so the dark red
color is used instead.

![j](https://user-images.githubusercontent.com/9215359/28685495-dcda05da-72bc-11e7-9c77-f63b61c43ede.png)
