### PR TITLE
Fix the invisible text color for completion suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.css
 *.css.map
 !jira.css
+.sass-cache/

--- a/input.scss
+++ b/input.scss
@@ -29,3 +29,7 @@ form.aui option,
     background: $secondary !important;
     color: $primary !important;
 }
+
+.atlassian-autocomplete .suggestions li {
+    color: $primary;
+}

--- a/jira.css
+++ b/jira.css
@@ -44,9 +44,11 @@ form.aui option,
   background: #1a1a1a !important;
   color: #ededed !important; }
 
+.atlassian-autocomplete .suggestions li {
+  color: #ededed; }
+
 #syntaxplugin span[style*="black"] {
   color: #FFFFFF !important; }
-
 #syntaxplugin span[style*="blue"] {
   color: #42769a !important; }
 


### PR DESCRIPTION
Currently, the autocomplete suggestions are invisible because they have
the same text and background colors, except when an item is highlighted.
This patch sets the text color to the primary white color.

<img width="734" alt="c0" src="https://user-images.githubusercontent.com/9215359/28725853-a968a956-7373-11e7-86de-6ad5349a782f.png">
=>
<img width="544" alt="c1" src="https://user-images.githubusercontent.com/9215359/28725857-ad115d82-7373-11e7-8922-ad0da489d04f.png">
