### PR TITLE
Make headers in ticket's description more visible

### DIFF
--- a/colors.scss
+++ b/colors.scss
@@ -12,3 +12,4 @@ $brightHighlight: lighten($colour, 10%);
 $brighterHighlight: lighten($colour, 20%);
 $brightestHighlight: lighten($colour, 30%);
 
+$userHeader: bisque;

--- a/fonts.scss
+++ b/fonts.scss
@@ -13,3 +13,18 @@ h3,
 h4 {
     color: $brighterHighlight !important;
 }
+
+.user-content-block h1,
+.user-content-block h2,
+.user-content-block h3,
+.user-content-block h4,
+.user-content-block h5,
+.user-content-block h6,
+.user-content-block:hover h1,
+.user-content-block:hover h2,
+.user-content-block:hover h3,
+.user-content-block:hover h4,
+.user-content-block:hover h5,
+.user-content-block:hover h6 {
+    color: $userHeader !important;
+}

--- a/jira.css
+++ b/jira.css
@@ -46,7 +46,6 @@ form.aui option,
 
 #syntaxplugin span[style*="black"] {
   color: #FFFFFF !important; }
-
 #syntaxplugin span[style*="blue"] {
   color: #42769a !important; }
 
@@ -157,6 +156,20 @@ h2,
 h3,
 h4 {
   color: #325b77 !important; }
+
+.user-content-block h1,
+.user-content-block h2,
+.user-content-block h3,
+.user-content-block h4,
+.user-content-block h5,
+.user-content-block h6,
+.user-content-block:hover h1,
+.user-content-block:hover h2,
+.user-content-block:hover h3,
+.user-content-block:hover h4,
+.user-content-block:hover h5,
+.user-content-block:hover h6 {
+  color: bisque !important; }
 
 #footer,
 #footer * {


### PR DESCRIPTION
They are currently of a dark blue color, which isn't very readable on
the dark background. This patch changes the color to "bisque", which is
slightly different from white.

<img width="867" alt="h0" src="https://user-images.githubusercontent.com/9215359/28726547-7818bea6-7376-11e7-9d20-8de40991fb07.png">
=>
<img width="847" alt="h2" src="https://user-images.githubusercontent.com/9215359/28726549-7b128862-7376-11e7-81fc-290f17c04eb7.png">