### PR TITLE
Make the sprint column headers more visible

### DIFF
--- a/agile.scss
+++ b/agile.scss
@@ -45,3 +45,7 @@
 .ghx-columns .ghx-busted-max {
     background: $warning !important;
 }
+
+.ghx-column h2 {
+    color: $primary !important;
+}

--- a/jira.css
+++ b/jira.css
@@ -49,7 +49,6 @@ form.aui option,
 
 #syntaxplugin span[style*="black"] {
   color: #FFFFFF !important; }
-
 #syntaxplugin span[style*="blue"] {
   color: #42769a !important; }
 
@@ -94,6 +93,9 @@ code {
 .ghx-columns .ghx-busted,
 .ghx-columns .ghx-busted-max {
   background: #8b0000 !important; }
+
+.ghx-column h2 {
+  color: #ededed !important; }
 
 .ghx-backlog-header,
 .ghx-end {


### PR DESCRIPTION
The current text color for them is dark blue, which is barely readable
on the gray background. This patch changes it to be the primary white
color.

<img width="938" alt="h0" src="https://user-images.githubusercontent.com/9215359/28784587-b45da3c8-75c8-11e7-904a-a82253bbad7b.png">
=>
<img width="937" alt="h1" src="https://user-images.githubusercontent.com/9215359/28784588-b67162f8-75c8-11e7-86f8-eab781212451.png">
