### PR TITLE
Make popup text more visible

### DIFF
--- a/jira.css
+++ b/jira.css
@@ -49,7 +49,6 @@ form.aui option,
 
 #syntaxplugin span[style*="black"] {
   color: #FFFFFF !important; }
-
 #syntaxplugin span[style*="blue"] {
   color: #42769a !important; }
 
@@ -204,6 +203,9 @@ h4 {
 .aui-dialog2-footer * {
   background: #4d4d4d !important;
   color: #ededed !important; }
+
+.aui-message {
+  color: #ededed; }
 
 .layout .column .placeholder,
 .layout .column.empty .empty-text {

--- a/popups.scss
+++ b/popups.scss
@@ -20,3 +20,7 @@
     background: $brighterSecondary !important;
     color: $primary !important;
 }
+
+.aui-message {
+    color: $primary;
+}


### PR DESCRIPTION
It's currently displayed as black on gray text. The patch changes it to
primary white on gray.

<img width="355" alt="m0" src="https://user-images.githubusercontent.com/9215359/28785558-9facebac-75cb-11e7-81f3-c254a13c6f26.png">
=>
<img width="355" alt="m1" src="https://user-images.githubusercontent.com/9215359/28785563-a17e8dc8-75cb-11e7-9648-697e960da819.png">
