### PR TITLE
Make white popup text important

### DIFF
--- a/jira.css
+++ b/jira.css
@@ -205,7 +205,7 @@ h4 {
   color: #ededed !important; }
 
 .aui-message {
-  color: #ededed; }
+  color: #ededed !important; }
 
 .layout .column .placeholder,
 .layout .column.empty .empty-text {

--- a/popups.scss
+++ b/popups.scss
@@ -22,5 +22,5 @@
 }
 
 .aui-message {
-    color: $primary;
+    color: $primary !important;
 }


### PR DESCRIPTION
This continues commit a79e05a977035a7af7ea2ecb1493a2cbd6c877d8, because
the text color in popups when ticket status is updated was still dark.
Now it's marked as `!important` to work there as well.

<img width="406" alt="m0" src="https://user-images.githubusercontent.com/9215359/28835563-9fad6288-769a-11e7-97b7-68ed19833d2c.png">
=>
<img width="407" alt="m1" src="https://user-images.githubusercontent.com/9215359/28835566-a19f4a8e-769a-11e7-9ed7-b86ccb86ea44.png">
